### PR TITLE
Dirty fix: Handle disconnecting issues

### DIFF
--- a/client/src/Root.tsx
+++ b/client/src/Root.tsx
@@ -3,7 +3,6 @@ import { useCallback, useMemo } from 'react'
 import { Provider } from 'react-redux'
 import { StyleSheetManager } from 'styled-components'
 import { ApiContextProvider } from './context/ApiContext'
-import { EventsContextProvider } from './context/EventsContext'
 import { LocaleContextProvider } from './context/LocaleContext'
 import { App } from './pages/App/App'
 import { buildStore } from './store'
@@ -21,9 +20,7 @@ const RootComponent = () => {
 			<Provider store={store}>
 				<LocaleContextProvider language={'en'}>
 					<ApiContextProvider>
-						<EventsContextProvider>
-							<App />
-						</EventsContextProvider>
+						<App />
 					</ApiContextProvider>
 				</LocaleContextProvider>
 			</Provider>

--- a/client/src/api/api.ts
+++ b/client/src/api/api.ts
@@ -9,13 +9,15 @@ import { encode, decode } from 'msgpack-lite'
 export class Client {
 	server: string
 	socket?: WebSocket
+	gameId?: string
 
 	onOpen?: () => void
 	onClose?: () => void
 	onMessage?: (data: GameMessage) => void
 
-	constructor(server: string) {
+	constructor(server: string, gameId: string) {
 		this.server = server
+		this.gameId = gameId
 		this.connect()
 	}
 

--- a/client/src/components/Flex/Flex.tsx
+++ b/client/src/components/Flex/Flex.tsx
@@ -9,6 +9,7 @@ export const Flex = styled.div<{
 		| 'space-between'
 		| 'space-around'
 	direction?: 'row' | 'column'
+	gap?: string | number
 }>`
 	display: flex;
 	min-height: 0;
@@ -16,5 +17,6 @@ export const Flex = styled.div<{
 		align-items: ${props.align || 'center'};
 		justify-content: ${props.justify || 'flex-start'};
 		flex-direction: ${props.direction || 'row'};
+		gap: ${props.gap || '0'};
 	`}
 `

--- a/client/src/pages/App/App.tsx
+++ b/client/src/pages/App/App.tsx
@@ -22,6 +22,7 @@ const THEME_MAP = {
 
 export const App = () => {
 	const apiState = useAppStore((state) => state.api.state)
+	const reconnecting = useAppStore((state) => state.api.reconnecting)
 	const dispatch = useAppDispatch()
 	const theme = useAppStore((state) => state.settings.data.theme)
 
@@ -46,6 +47,8 @@ export const App = () => {
 		dispatch(loadSettings())
 	}, [])
 
+	console.log({ apiState: ApiState[apiState], reconnecting })
+
 	return (
 		<ThemeProvider theme={themeData}>
 			<AppContainer id="stars">
@@ -54,7 +57,8 @@ export const App = () => {
 				{apiState !== ApiState.Ready && apiState !== ApiState.Joined && (
 					<Connect />
 				)}
-				{apiState === ApiState.Joined && <Game />}
+				{(apiState === ApiState.Joined ||
+					(apiState === ApiState.Connected && reconnecting)) && <Game />}
 
 				<ApiErrorMessage />
 				<SoundController />

--- a/client/src/pages/Game/pages/Table/Table.tsx
+++ b/client/src/pages/Game/pages/Table/Table.tsx
@@ -22,24 +22,6 @@ const Table = () => {
 	const spectating = useAppStore((state) => state.game.spectating)
 	const [pickerHidden, setPickerHidden] = useState(false)
 
-	/*
-	const events = useEvents()
-	const lastEvent = useRef<RealtimeEventEmit | null>()
-
-	useAnimationFrame(() => {
-		if (lastEvent.current) {
-			events.send(lastEvent.current)
-			lastEvent.current = null
-		}
-	})
-
-	useWindowEvent('mousemove', (e: MouseEvent) => {
-		const pos = [e.clientX / window.innerWidth, e.clientY / window.innerHeight]
-
-		lastEvent.current = mouseMoveEvent(pos[0], pos[1])
-	})
-	*/
-
 	useEffect(() => {
 		if (
 			pending?.type !== PlayerActionType.PickCards &&

--- a/client/src/pages/Main/components/NewGameModal.tsx
+++ b/client/src/pages/Main/components/NewGameModal.tsx
@@ -48,6 +48,17 @@ export const NewGameModal = ({ onClose }: Props) => {
 	const [bots, setBots] = useState(0)
 	const [solarPhase, setSolarPhase] = useState(true)
 	const [fastBots, setFastBots] = useState(false)
+
+	const [
+		disablePlayersAfterDisconnecting,
+		setDisablePlayersAfterDisconnecting,
+	] = useState(true)
+
+	const [
+		disablePlayersAfterDisconnectingInSeconds,
+		setDisablePlayersAfterDisconnectingInSeconds,
+	] = useState(60)
+
 	const serverInfo = useAppStore((app) => app.api.info)
 
 	const [expansions, setExpansions] = useState([
@@ -88,6 +99,10 @@ export const NewGameModal = ({ onClose }: Props) => {
 				draft,
 				solarPhase,
 				fastBots,
+				disablePlayersAfterDisconnectingInSeconds:
+					disablePlayersAfterDisconnecting
+						? disablePlayersAfterDisconnectingInSeconds
+						: undefined,
 			})
 
 			if (res.id) {
@@ -195,6 +210,29 @@ export const NewGameModal = ({ onClose }: Props) => {
 						onChange={(v) => setSpectators(v)}
 						label="Allow spectators"
 					/>
+
+					<Checkbox
+						checked={disablePlayersAfterDisconnecting}
+						onChange={(v) => setDisablePlayersAfterDisconnecting(v)}
+						label="Disable players after disconnecting - their turns will be automatically skipped"
+					/>
+
+					{disablePlayersAfterDisconnecting && (
+						<TimeoutField align="center" gap={'0.5rem'}>
+							<div>After</div>
+							<TimeoutInput
+								value={disablePlayersAfterDisconnectingInSeconds?.toString()}
+								onChange={(v) =>
+									setDisablePlayersAfterDisconnectingInSeconds(+v)
+								}
+								type="number"
+								step="1"
+								min="5"
+								max="216000"
+							/>
+							<div>seconds</div>
+						</TimeoutField>
+					)}
 				</Field>
 
 				<Field>
@@ -309,3 +347,11 @@ const SelectItemDesc = styled.div`
 const ExpansionsMultiSelect = styled(MultiSelect)`
 	max-width: 30rem;
 ` as typeof MultiSelect
+
+const TimeoutField = styled(Flex)`
+	margin-left: 1rem;
+`
+
+const TimeoutInput = styled(Input)`
+	width: 6rem;
+`

--- a/client/src/store/modules/api/index.ts
+++ b/client/src/store/modules/api/index.ts
@@ -15,6 +15,7 @@ const initialState = {
 	gameId: null as string | null,
 	state: ApiState.Ready,
 	info: null as ServerInfo | null,
+	reconnecting: false,
 }
 
 export default (state = initialState, action: Actions): State => {

--- a/server/src/server/game-client.ts
+++ b/server/src/server/game-client.ts
@@ -98,7 +98,12 @@ export class Client {
 						(p) => p !== this && p.player?.id === player.id,
 					) === undefined
 				) {
-					this.logger.log('Client disconnected - starting disconnect timer')
+					this.logger.log(
+						'Client disconnected' +
+							this.game.config.disablePlayersWhenDisconnectedForInSeconds
+							? ' - starting disconnect disable timer'
+							: '',
+					)
 
 					player.handleDisconnect()
 				} else {

--- a/server/src/server/game-client.ts
+++ b/server/src/server/game-client.ts
@@ -100,9 +100,9 @@ export class Client {
 				) {
 					this.logger.log(
 						'Client disconnected' +
-							this.game.config.disablePlayersWhenDisconnectedForInSeconds
-							? ' - starting disconnect disable timer'
-							: '',
+							(this.game.config.disablePlayersWhenDisconnectedForInSeconds
+								? ' - starting disconnect disable timer'
+								: ''),
 					)
 
 					player.handleDisconnect()

--- a/server/src/server/http/controllers/games-controller.ts
+++ b/server/src/server/http/controllers/games-controller.ts
@@ -83,6 +83,8 @@ export const gamesController = appController(
 				fastBots: request.fastBots,
 				draft,
 				solarPhase,
+				disablePlayersWhenDisconnectedForInSeconds:
+					request.disablePlayersAfterDisconnectingInSeconds,
 			})
 
 			logger.log(`New ${gameServer.id} - ${name}`)

--- a/server/src/server/http/validators/new-game-validator.ts
+++ b/server/src/server/http/validators/new-game-validator.ts
@@ -27,4 +27,7 @@ export const newGameValidator = object({
 	map: enums([MapType.Elysium, MapType.Hellas, MapType.Standard]),
 	solarPhase: optional(boolean()),
 	fastBots: optional(boolean()),
+	disablePlayersAfterDisconnectingInSeconds: optional(
+		min(max(integer(), 216000), 5),
+	),
 })

--- a/shared/src/game/game.ts
+++ b/shared/src/game/game.ts
@@ -12,8 +12,11 @@ import {
 	pickCards,
 	pickPreludes,
 	playerPass,
+	solarPhaseTerraform,
 	UpdateDeepPartial,
 } from '@shared/index'
+import { Logger } from '@shared/lib/logger'
+import { StateMachine } from '@shared/lib/state-machine'
 import { MapType } from '@shared/map'
 import { Maps } from '@shared/maps'
 import { GameModes } from '@shared/modes'
@@ -22,6 +25,9 @@ import { PlayerActionType } from '@shared/player-actions'
 import { ProgressMilestones } from '@shared/progress-milestones'
 import { initialGameState } from '@shared/states'
 import { f, isMarsTerraformed, range, shuffle } from '@shared/utils'
+import { deepExtend } from '@shared/utils/collections'
+import { MyEvent } from '@shared/utils/events'
+import { randomPassword } from '@shared/utils/password'
 import { v4 as uuidv4 } from 'uuid'
 import { Bot } from './bot'
 import { BotNames } from './bot-names'
@@ -33,6 +39,7 @@ import { GenerationInProgressGameState } from './game/generation-in-progress-gam
 import { GenerationStartGameState } from './game/generation-start-game-state'
 import { PreludeGameState } from './game/prelude-game-state'
 import { ResearchPhaseGameState } from './game/research-phase-game-state'
+import { SolarPhaseGameState } from './game/solar-phase-game-state'
 import { StartingGameState } from './game/starting-game-state'
 import { WaitingForPlayersGameState } from './game/waiting-for-players-game-state'
 import {
@@ -42,16 +49,8 @@ import {
 	ProjectBought,
 	TilePlacedEvent,
 } from './player'
-import { SolarPhaseGameState } from './game/solar-phase-game-state'
-import { randomPassword } from '@shared/utils/password'
-import { deepExtend } from '@shared/utils/collections'
-import { MyEvent } from '@shared/utils/events'
-import { StateMachine } from '@shared/lib/state-machine'
-import { Logger } from '@shared/lib/logger'
 
 export interface GameConfig {
-	lockSystem: GameLockSystem
-
 	bots: number
 	adminPassword: string
 	mode: GameModeType
@@ -65,6 +64,9 @@ export interface GameConfig {
 
 	fastBots: boolean
 	fastProduction: boolean
+
+	/** Disable players (skip their turn) when they're disconnected for specified number of seconds */
+	disablePlayersWhenDisconnectedForInSeconds?: number
 }
 
 export interface GameLockSystem {
@@ -83,7 +85,7 @@ export class Game {
 		return this.baseLogger.duplicate(`Game(${shortId})`)
 	}
 
-	config: Omit<GameConfig, 'lockSystem'>
+	config: GameConfig
 
 	state = initialGameState(uuidv4())
 
@@ -116,6 +118,7 @@ export class Game {
 			fastProduction: false,
 			draft: false,
 			solarPhase: false,
+			disablePlayersWhenDisconnectedForInSeconds: 30,
 			...config,
 		}
 
@@ -198,7 +201,9 @@ export class Game {
 		return this.botNames.pop() || `Bot ${id}`
 	}
 
-	load = (state: GameState) => {
+	load = (state: GameState, config: GameConfig) => {
+		this.config = config
+
 		this.state = state
 		this.players = []
 
@@ -471,7 +476,15 @@ export class Game {
 				try {
 					if (!p.state.connected) {
 						if (p.state.state !== PlayerStateValue.Playing) {
-							if (p.state.pendingActions.length > 0) {
+							if (p.state.state === PlayerStateValue.SolarPhaseTerraform) {
+								const availableProgressValues = (
+									['oceans', 'temperature', 'oxygen'] as const
+								).filter(
+									(progress) => this.state[progress] < this.state.map[progress],
+								)
+
+								p.performAction(solarPhaseTerraform(availableProgressValues[0]))
+							} else if (p.state.pendingActions.length > 0) {
 								p.state.pendingActions.forEach((a) => {
 									if (a.type === PlayerActionType.PickStarting) {
 										// Starting pick can stall others!
@@ -488,6 +501,8 @@ export class Game {
 									if (a.type === PlayerActionType.DraftCard) {
 										p.performAction(draftCard([0]))
 									}
+
+									// TODO: Tons of other actions here
 								})
 							}
 						}

--- a/shared/src/game/game/generation-ending-state.ts
+++ b/shared/src/game/game/generation-ending-state.ts
@@ -42,7 +42,7 @@ export class GenerationEndingState extends BaseGameState {
 
 			if (lock) {
 				this.clearLock()
-				this.game.load(lock)
+				this.game.load(lock, this.game.config)
 				this.onEnter()
 			}
 		}

--- a/shared/src/game/player.ts
+++ b/shared/src/game/player.ts
@@ -189,6 +189,12 @@ export class Player {
 	}
 
 	handleDisconnect() {
+		if (
+			this.game.config.disablePlayersWhenDisconnectedForInSeconds === undefined
+		) {
+			return
+		}
+
 		if (this.disconnectTimeout) {
 			clearTimeout(this.disconnectTimeout)
 		}
@@ -196,7 +202,7 @@ export class Player {
 		this.disconnectTimeout = setTimeout(() => {
 			this.state.connected = false
 			this.updated()
-		}, 10000)
+		}, this.game.config.disablePlayersWhenDisconnectedForInSeconds * 1000)
 	}
 
 	finishGame() {

--- a/shared/src/requests.ts
+++ b/shared/src/requests.ts
@@ -13,4 +13,5 @@ export type NewGameRequest = {
 	draft?: boolean
 	solarPhase?: boolean
 	fastBots?: boolean
+	disablePlayersAfterDisconnectingInSeconds?: number
 }


### PR DESCRIPTION
## Describe your changes

We're running behind CloudFlare which interrupts the WS connection every ~100 seconds which caused issues with our FE. Bascially on every reconnect the whole FE would reset so anything the player was doing at that moment is lost and all event handlers are triggered. I've fixed this by some really dirty code, the whole FE websocket handling should be rewritten, fixing this issue was a pain and the solution is dirty.

Also while I was fixing this, I've made _player disable due to disconnect_ optional so you can both disable the feature or change the interval so the player has enough time to reconnect if they have connection issues. The default value is 1 minute.

I've also fixed the fact that the game config wasn't saved together with the game state so if the game was _ressurected_ from file, you would end up with the default config which is now an issue since the config holds some values that are used mid-game. Previously this wasn't needed as the config only changed the starting configuration.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests if possible
- [x] I adhere to best practices defined for this project
- [x] I adhere to code style defined for this project
