### PR TITLE
Fix solar phase being triggered even when progress is done

### DIFF
--- a/shared/src/game/game/generation-in-progress-game-state.ts
+++ b/shared/src/game/game/generation-in-progress-game-state.ts
@@ -37,8 +37,7 @@ export class GenerationInProgressGameState extends BaseGameState {
 		if (this.game.all(PlayerStateValue.Passed)) {
 			if (
 				this.game.state.solarPhase &&
-				(this.game.state.venus < this.game.state.map.venus ||
-					this.game.state.temperature < this.game.state.map.temperature ||
+				(this.game.state.temperature < this.game.state.map.temperature ||
 					this.game.state.oxygen < this.game.state.map.oxygen ||
 					this.game.state.oceans < this.game.state.map.oceans)
 			) {


### PR DESCRIPTION
## Describe your changes

You can't increase venus as WG project so we shouldn't go to solar phase when progress is done.