### PR TITLE
Allow selecting itself when putting playEffect has anyCardResourceChange

### DIFF
--- a/client/src/pages/Game/pages/Table/components/CardBuy/components/Arg.tsx
+++ b/client/src/pages/Game/pages/Table/components/CardBuy/components/Arg.tsx
@@ -44,7 +44,12 @@ export const Arg = ({
 			)
 		case CardEffectTarget.Card:
 			return (
-				<CardArg arg={arg} onChange={onChange} handCardIndex={handCardIndex} />
+				<CardArg
+					arg={arg}
+					onChange={onChange}
+					handCardIndex={handCardIndex}
+					cardState={cardState}
+				/>
 			)
 		case CardEffectTarget.PlayerCardResource:
 			return (
@@ -53,6 +58,7 @@ export const Arg = ({
 					onChange={onChange}
 					handCardIndex={handCardIndex}
 					otherPlayer={true}
+					cardState={cardState}
 				/>
 			)
 		case CardEffectTarget.PlayerResource:

--- a/client/src/pages/Game/pages/Table/components/CardBuy/components/CardArg.tsx
+++ b/client/src/pages/Game/pages/Table/components/CardBuy/components/CardArg.tsx
@@ -8,10 +8,12 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { CardInfo } from '../../CardDisplay/CardDisplay'
 import { CardSelector } from '../../CardSelector/CardSelector'
 import { ArgContainer } from './ArgContainer'
+import { UsedCardState } from '@shared/game'
 
 type Props = {
 	arg: CardEffectArgument
 	handCardIndex?: number
+	cardState: UsedCardState
 	otherPlayer?: boolean
 	onChange: (v: number | [number, number]) => void
 }
@@ -21,6 +23,7 @@ export const CardArg = ({
 	handCardIndex,
 	onChange,
 	otherPlayer,
+	cardState,
 }: Props) => {
 	const locale = useLocale()
 
@@ -56,20 +59,37 @@ export const CardArg = ({
 
 	const [selectedPlayer, setSelectedPlayer] = useState(0)
 
-	const cards = useMemo(
-		() =>
+	const cards = useMemo(() => {
+		const result =
 			usedCards && handCards && game && playerState && playerId
 				? cardsToCardList(
-						arg.fromHand ? handCards.map((c) => emptyCardState(c)) : usedCards,
+						arg.fromHand
+							? handCards.map((c) => emptyCardState(c))
+							: arg.allowSelfCard
+								? [...usedCards, emptyCardState(cardState.code)]
+								: usedCards,
 						arg.cardConditions,
 						{
 							game,
 							player: playerState,
 						},
 					)
-				: [],
-		[usedCards],
-	)
+				: []
+
+		// when allowSelfCard is true, we've pushed the card itself to the end, but it has incorrect index
+		// -1 is a special value that means the card itself
+		if (arg.allowSelfCard && result[result.length - 1].state?.index === -1) {
+			result[result.length - 1].index = -1
+		}
+
+		return result
+	}, [usedCards, arg, playerState, game, playerId, handCards])
+
+	console.log({
+		allowSelfCard: arg.allowSelfCard,
+		arg,
+		selfCode: cardState.code,
+	})
 
 	const handleSubmit = useCallback(
 		(cards: CardInfo[]) => {

--- a/client/src/pages/Game/pages/Table/components/CardBuy/components/CardArg.tsx
+++ b/client/src/pages/Game/pages/Table/components/CardBuy/components/CardArg.tsx
@@ -66,7 +66,9 @@ export const CardArg = ({
 						arg.fromHand
 							? handCards.map((c) => emptyCardState(c))
 							: arg.allowSelfCard
-								? [...usedCards, emptyCardState(cardState.code)]
+								? // Add the bought card itself as last (to not corrupt indexes), use -13 to mark it
+									// By putting the card through cardsToCardList, we ensure it's only shown when compatible with the action
+									[...usedCards, emptyCardState(cardState.code, -13)]
 								: usedCards,
 						arg.cardConditions,
 						{
@@ -77,8 +79,8 @@ export const CardArg = ({
 				: []
 
 		// when allowSelfCard is true, we've pushed the card itself to the end, but it has incorrect index
-		// -1 is a special value that means the card itself
-		if (arg.allowSelfCard && result[result.length - 1].state?.index === -1) {
+		// -13 is special value that indicates it's indeed the card we added, -1 is a special value that means the card itself
+		if (arg.allowSelfCard && result[result.length - 1].state?.index === -13) {
 			result[result.length - 1].index = -1
 		}
 

--- a/client/src/pages/Game/pages/Table/components/EventList/components/EventLine.tsx
+++ b/client/src/pages/Game/pages/Table/components/EventList/components/EventLine.tsx
@@ -176,7 +176,7 @@ export const EventLine = ({ event, animated, onDone }: Props) => {
 						<PlayerSpan player={players[event.playerId]} />{' '}
 						{event.amount > 0 ? '+' : '-'}
 						{Math.abs(event.amount)} {event.resource}
-						{' to '}
+						{event.amount > 0 ? ' to ' : ' from '}
 						<CardSpan card={event.card} />
 					</>
 				)

--- a/client/src/store/modules/game/utils.ts
+++ b/client/src/store/modules/game/utils.ts
@@ -75,7 +75,7 @@ export const getEvents = (lastGame: GameState, game: GameState) => {
 							} else {
 								const card = CardsLookupApi.get(oldCard.code)
 
-								if (card.resource && cardChanges[card.resource]) {
+								if (card.resource && cardChanges[card.resource] !== undefined) {
 									newEvents.push({
 										type: EventType.CardResourceChanged,
 										playerId: player.id,

--- a/shared/src/cards/__tests__/joined-effects.test.ts
+++ b/shared/src/cards/__tests__/joined-effects.test.ts
@@ -1,6 +1,6 @@
 import { prepareTestState } from '../../test/utils'
 import { emptyCardState } from '../utils'
-import { joinedEffects, playerResourceChange, resourceChange } from '../effects'
+import { joinedEffects, playerResourceChange, resourceChange } from '../effectsGrouped'
 
 test('joinedEffect should properly work with arguments', () => {
 	const card = emptyCardState('void')

--- a/shared/src/cards/__tests__/player-production-change.test.ts
+++ b/shared/src/cards/__tests__/player-production-change.test.ts
@@ -1,5 +1,5 @@
 import { prepareTestState } from '../../test/utils'
-import { playerProductionChange } from '../effects'
+import { playerProductionChange } from '../effectsGrouped'
 import { emptyCardState } from '../utils'
 
 test('playerProductionChange should change production of right player', () => {

--- a/shared/src/cards/__tests__/player-resource-change.test.ts
+++ b/shared/src/cards/__tests__/player-resource-change.test.ts
@@ -1,5 +1,5 @@
 import { prepareTestState } from '../../test/utils'
-import { playerResourceChange } from '../effects'
+import { playerResourceChange } from '../effectsGrouped'
 import { emptyCardState } from '../utils'
 
 test('playerResourceChange should change resources of right player', () => {

--- a/shared/src/cards/__tests__/resource-change.test.ts
+++ b/shared/src/cards/__tests__/resource-change.test.ts
@@ -1,5 +1,5 @@
 import { prepareTestState } from '../../test/utils'
-import { resourceChange } from '../effects'
+import { resourceChange } from '../effectsGrouped'
 import { emptyCardState } from '../utils'
 import { Resource } from '../types'
 

--- a/shared/src/cards/base/cards.ts
+++ b/shared/src/cards/base/cards.ts
@@ -52,7 +52,7 @@ import {
 	terraformRatingForTags,
 	titanPriceChange,
 	triggerCardResourceChange,
-} from '../effects'
+} from '../effectsGrouped'
 import { exchangeProduction } from '../effects/exchange-production'
 import { productionForTags } from '../effects/production-for-tags'
 import { voidEffect } from '../effects/voidEffect'

--- a/shared/src/cards/base/corporations.ts
+++ b/shared/src/cards/base/corporations.ts
@@ -11,7 +11,7 @@ import {
 	productionChange,
 	resourceChange,
 	titanPriceChange,
-} from '../effects'
+} from '../effectsGrouped'
 import { asFirstAction, passiveEffect } from '../passive-effects'
 import { Card, CardCategory, CardSpecial, CardType, SymbolType } from '../types'
 import {

--- a/shared/src/cards/effects.ts
+++ b/shared/src/cards/effects.ts
@@ -631,8 +631,15 @@ export const anyCardResourceChange = (
 									),
 						}),
 					]
-				: // TODO: Add condition that requires player to own card with that resource?
-					[],
+				: [
+						condition({
+							description: `Player has to have a card that accepts ${res}`,
+							evaluate: ({ player }) =>
+								!!player.usedCards
+									.map((c) => ({ card: CardsLookupApi.get(c.code), state: c }))
+									.find(({ card }) => card.resource === res),
+						}),
+					],
 		description:
 			amount < 0
 				? `Remove ${withUnits(res, -amount)} from any card${
@@ -748,6 +755,7 @@ export const anyCardResourceChangePerTag = (
 						? [cardResourceCondition(res, -amount)]
 						: [cardAcceptsResource(res)]),
 				]),
+				allowSelfCard: true,
 				descriptionPrefix:
 					amount > 0
 						? `Add 1 per ${CardCategory[tag]} of ${res} to`

--- a/shared/src/cards/effects/__tests__/terraforming-rating-for-tags.test.ts
+++ b/shared/src/cards/effects/__tests__/terraforming-rating-for-tags.test.ts
@@ -1,6 +1,6 @@
 import { prepareTestState } from '../../../test/utils'
 import { emptyCardState } from '../../utils'
-import { terraformRatingForTags } from '../../effects'
+import { terraformRatingForTags } from '../../effectsGrouped'
 import { CardCategory } from '../../types'
 
 test('terraformRatingForTags should change production based on tag count', () => {

--- a/shared/src/cards/effectsGrouped.ts
+++ b/shared/src/cards/effectsGrouped.ts
@@ -615,6 +615,7 @@ export const anyCardResourceChange = (
 					amount > 0
 						? `Add ${withUnits(res, amount)} to`
 						: `Remove ${withUnits(res, -amount)} from`,
+				allowSelfCard: true,
 			},
 		],
 		conditions:
@@ -654,7 +655,20 @@ export const anyCardResourceChange = (
 							: ''
 					}`,
 		symbols: [{ cardResource: res, count: amount }],
-		perform: ({ player }, cardIndex: number) => {
+		perform: ({ player, card }, cardIndex: number) => {
+			// Play on self
+			if (cardIndex === -1) {
+				const cardInfo = CardsLookupApi.get(card.code)
+
+				if (cardInfo.resource !== res) {
+					throw new Error(`${card.code} doesn't accept ${res}`)
+				}
+
+				card[res] += amount
+
+				return
+			}
+
 			if (typeof cardIndex === 'number' && cardIndex >= 0) {
 				const cardState = player.usedCards[cardIndex]
 
@@ -756,7 +770,6 @@ export const anyCardResourceChangePerTag = (
 						? [cardResourceCondition(res, -amount)]
 						: [cardAcceptsResource(res)]),
 				]),
-				allowSelfCard: true,
 				descriptionPrefix:
 					amount > 0
 						? `Add 1 per ${CardCategory[tag]} of ${res} to`

--- a/shared/src/cards/prelude/cards.ts
+++ b/shared/src/cards/prelude/cards.ts
@@ -1,7 +1,7 @@
 import { GridCellContent } from '../../game'
 import { LavaCells } from '../../map'
 import { cardCategoryCountCondition, gameProgressConditionMax } from '../conditions'
-import { getTopCards, placeTile, productionChange } from '../effects'
+import { getTopCards, placeTile, productionChange } from '../effectsGrouped'
 import { Card, CardCategory, CardSpecial, CardType } from '../types'
 import { card } from '../utils'
 

--- a/shared/src/cards/prelude/corporations.ts
+++ b/shared/src/cards/prelude/corporations.ts
@@ -9,7 +9,7 @@ import {
 	lowestProductionChange,
 	sponsorCompetitionForFree,
 	joinedEffects,
-} from '../effects'
+} from '../effectsGrouped'
 import { passiveEffect, asFirstAction } from '../passive-effects'
 import { CardCategory, CardSpecial, CardType } from '../types'
 import { card, withRightArrow, updatePlayerResource } from '../utils'

--- a/shared/src/cards/prelude/prelude.ts
+++ b/shared/src/cards/prelude/prelude.ts
@@ -12,7 +12,7 @@ import {
 	gameProcessChange,
 	terraformRatingChange,
 	placeCity,
-} from '../effects'
+} from '../effectsGrouped'
 import { GridCellContent } from '../../game'
 import { resetProgressBonus, resetCardPriceChange } from '../passive-effects'
 

--- a/shared/src/cards/types.ts
+++ b/shared/src/cards/types.ts
@@ -197,6 +197,8 @@ export interface CardEffectArgument {
 	fromHand?: boolean
 	effects?: CardEffect[]
 	minAmount?: number
+	/** Allow selecting the card being played as the target - used for CARD inside playEffects */
+	allowSelfCard?: boolean
 }
 
 export type MaxAmountCallback = (ctx: CardCallbackContext) => number

--- a/shared/src/cards/venus/venusCards.ts
+++ b/shared/src/cards/venus/venusCards.ts
@@ -29,7 +29,7 @@ import {
 	resourcesForTiles,
 	deprecatedTagPriceChange,
 	terraformRatingChange,
-} from '../effects'
+} from '../effectsGrouped'
 import { cardResourcePerCardPlayed } from '../passive-effects'
 import { resourceAsPaymentForTags } from '../effects/resourceAsPaymentForTags'
 import { Card, CardCategory, CardSpecial, CardType } from '../types'

--- a/shared/src/cards/venus/venusCorporations.ts
+++ b/shared/src/cards/venus/venusCorporations.ts
@@ -3,7 +3,7 @@ import {
 	anyCardResourceChange,
 	productionChange,
 	resourceChange,
-} from '../effects'
+} from '../effectsGrouped'
 import { changeProgressConditionBonusPerTag } from '../effects/changeProgressConditionBonusPerTag'
 import { markCardAsUnplayed } from '../effects/mark-card-as-unplayed'
 import {

--- a/shared/src/expansions/colonies/coloniesCards.ts
+++ b/shared/src/expansions/colonies/coloniesCards.ts
@@ -22,7 +22,7 @@ import {
 	resourceChange,
 	resourcesForTiles,
 	terraformRatingChange,
-} from '@shared/cards/effects'
+} from '@shared/cards/effectsGrouped'
 import { changeColonyStep } from '@shared/cards/effects/changeColonyStep'
 import { freeTradeWithColony } from '@shared/cards/effects/freeTradeWithColony'
 import { gainAllColonyIncomeBonuses } from '@shared/cards/effects/gainAllColonyIncomeBonuses'

--- a/shared/src/expansions/colonies/coloniesCorporations.ts
+++ b/shared/src/expansions/colonies/coloniesCorporations.ts
@@ -10,7 +10,7 @@ import {
 	effectChoice,
 	productionChange,
 	resourceChange,
-} from '@shared/cards/effects'
+} from '@shared/cards/effectsGrouped'
 import { exchangeCardResourceForResource } from '@shared/cards/effects/exchangeCardResourceForResource'
 import { placeColony } from '@shared/cards/effects/placeColony'
 import {

--- a/shared/src/game/validation/args/card-arg-validator.ts
+++ b/shared/src/game/validation/args/card-arg-validator.ts
@@ -4,7 +4,9 @@ import { ValidatorContext } from './types'
 export const cardArgValidator = ({ a, ctx, value }: ValidatorContext) => {
 	const selected = a.fromHand
 		? emptyCardState(ctx.player.cards[value as number])
-		: ctx.player.usedCards[value as number]
+		: a.allowSelfCard && value === -1
+			? ctx.card
+			: ctx.player.usedCards[value as number]
 
 	const errors = a.cardConditions.filter(
 		(c) =>


### PR DESCRIPTION
## Describe your changes

Players can now pick the card being bought when buying a card with `anyCardResourceChange` play effect (if applicable).

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests if possible
- [x] I adhere to best practices defined for this project
- [x] I adhere to code style defined for this project
