### PR TITLE
Fix bots playing cards that result in worse score

### DIFF
--- a/shared/src/game/bot.ts
+++ b/shared/src/game/bot.ts
@@ -389,7 +389,7 @@ export class Bot extends Player {
 
 		switch (this.state.state) {
 			case PlayerStateValue.Waiting: {
-				actions.push([0, () => this.performAction(playerReady(true))])
+				actions.push([Infinity, () => this.performAction(playerReady(true))])
 				break
 			}
 
@@ -397,7 +397,7 @@ export class Bot extends Player {
 				const pending = this.pendingAction
 
 				if (pending) {
-					actions.push([0, () => this.performPending(pending)])
+					actions.push([Infinity, () => this.performPending(pending)])
 				} else {
 					this.logger.error('Nothing to do, yet I have to pick something...')
 				}
@@ -432,7 +432,7 @@ export class Bot extends Player {
 				const pending = this.pendingAction
 
 				if (pending) {
-					actions.push([0, () => this.performPending(pending)])
+					actions.push([Infinity, () => this.performPending(pending)])
 				}
 
 				break
@@ -442,7 +442,7 @@ export class Bot extends Player {
 				const pending = this.pendingAction
 
 				if (pending) {
-					actions.push([0, () => this.performPending(pending)])
+					actions.push([Infinity, () => this.performPending(pending)])
 				}
 
 				break
@@ -452,7 +452,7 @@ export class Bot extends Player {
 				const pending = this.pendingAction
 
 				if (pending) {
-					actions.push([0, () => this.performPending(pending)])
+					actions.push([Infinity, () => this.performPending(pending)])
 				} else {
 					if (
 						this.game.state.milestones.length < this.game.state.milestonesLimit
@@ -667,7 +667,9 @@ export class Bot extends Player {
 			}
 		}
 
-		actions = actions.filter(([s]) => s >= 0)
+		const currentScore = computeScore(this.game.state, this.state)
+
+		actions = actions.filter(([s]) => s >= currentScore)
 
 		this.logger.log(f('{0} actions available', actions.length))
 

--- a/shared/src/game/scoring/utils.ts
+++ b/shared/src/game/scoring/utils.ts
@@ -92,7 +92,7 @@ export const computeScore = (g: GameState, p: PlayerState) => {
 			(acc, p) => (acc ?? 0) + (p ?? 0),
 			0,
 		) ?? 0) +
-		p.cards.length * 0.5 +
+		p.cards.length * 0.3 +
 		resources.reduce(
 			(acc, r) =>
 				acc +


### PR DESCRIPTION
## Describe your changes

When deciding which action to play, filter out actions that result into worse score than current score. This may not be the best tactic, but it's better than playing a card that does nothing due to tag requirements etc.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests if possible
- [x] I adhere to best practices defined for this project
- [x] I adhere to code style defined for this project
