### PR TITLE
Fix card arg crashing when there's no card to pick

### DIFF
--- a/client/src/pages/Game/pages/Table/components/CardBuy/components/CardArg.tsx
+++ b/client/src/pages/Game/pages/Table/components/CardBuy/components/CardArg.tsx
@@ -80,7 +80,7 @@ export const CardArg = ({
 
 		// when allowSelfCard is true, we've pushed the card itself to the end, but it has incorrect index
 		// -13 is special value that indicates it's indeed the card we added, -1 is a special value that means the card itself
-		if (arg.allowSelfCard && result[result.length - 1].state?.index === -13) {
+		if (arg.allowSelfCard && result[result.length - 1]?.state?.index === -13) {
 			result[result.length - 1].index = -1
 		}
 


### PR DESCRIPTION
## Describe your changes

Nasty bug, when the card itself can't be picked due to conditions, this line would crash since there's nothing to pick from.


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests if possible
- [x] I adhere to best practices defined for this project
- [x] I adhere to code style defined for this project
