### PR TITLE
Improve card control buttons

### DIFF
--- a/client/src/pages/Game/pages/Table/components/CardView/CardView.styles.tsx
+++ b/client/src/pages/Game/pages/Table/components/CardView/CardView.styles.tsx
@@ -38,17 +38,21 @@ export const HeadSymbols = styled(Symbols)<{ $ok?: boolean }>`
 export const Action = styled.div<{
 	$hasSymbols: boolean
 	$highlight?: boolean
+	$highlightNoAnimation?: boolean
 }>`
 	padding: 0.5rem;
 
-	${({ theme, $highlight }) =>
+	${({ theme, $highlight, $highlightNoAnimation }) =>
 		$highlight
 			? css`
 					background: ${rgba(lighten(0.05, theme.colors.background), 1)};
 					border: 0.2rem solid ${lighten(0.1, theme.colors.border)};
-					animation-name: ${actionPop};
-					animation-duration: 0.5s;
-					animation-iteration-count: 1;
+					${!$highlightNoAnimation &&
+					css`
+						animation-name: ${actionPop};
+						animation-duration: 0.5s;
+						animation-iteration-count: 1;
+					`}
 				`
 			: css`
 					border: 0.1rem solid ${theme.colors.border};

--- a/client/src/pages/Game/pages/Table/components/CardView/CardView.tsx
+++ b/client/src/pages/Game/pages/Table/components/CardView/CardView.tsx
@@ -30,6 +30,8 @@ type Props = {
 	className?: string
 	style?: CSSProperties
 	hideAdjustedPrice?: boolean
+	highlightAction?: boolean
+	highlightActionNoAnimation?: boolean
 }
 
 export const CardView = ({
@@ -44,6 +46,8 @@ export const CardView = ({
 	onClick,
 	style,
 	hideAdjustedPrice,
+	highlightAction,
+	highlightActionNoAnimation,
 }: Props) => {
 	const game = useAppStore((state) => state.game.state)
 	const player = useAppStore((state) => state.game.player)
@@ -154,6 +158,8 @@ export const CardView = ({
 			affordable={affordable}
 			conditionContext={condContext}
 			calculatedVps={calculatedVps}
+			highlightAction={highlightAction}
+			highlightActionNoAnimation={highlightActionNoAnimation}
 		/>
 	)
 }

--- a/client/src/pages/Game/pages/Table/components/CardView/StatelessCardView.tsx
+++ b/client/src/pages/Game/pages/Table/components/CardView/StatelessCardView.tsx
@@ -48,6 +48,7 @@ type Props = {
 	conditionContext?: CardCallbackContext
 	calculatedVps?: number
 	highlightAction?: boolean
+	highlightActionNoAnimation?: boolean
 }
 
 export const StatelessCardView = ({
@@ -68,6 +69,7 @@ export const StatelessCardView = ({
 	highlightAction,
 	adjustedPrice,
 	adjustedPriceContext,
+	highlightActionNoAnimation,
 }: Props) => {
 	const locale = useLocale()
 	const settings = useAppStore((state) => state.settings.data)
@@ -211,7 +213,11 @@ export const StatelessCardView = ({
 				{card.actionEffects.filter(
 					(a) => a.description?.length || a.symbols.length,
 				).length > 0 && (
-					<Action $hasSymbols={symbols.length > 0} $highlight={highlightAction}>
+					<Action
+						$hasSymbols={symbols.length > 0}
+						$highlight={highlightAction}
+						$highlightNoAnimation={highlightActionNoAnimation}
+					>
 						<ActionTitle $highlight={highlightAction}>Action</ActionTitle>
 
 						<Symbols symbols={playActionSymbols} />

--- a/client/src/pages/Game/pages/Table/components/Controls/components/CardsView.tsx
+++ b/client/src/pages/Game/pages/Table/components/Controls/components/CardsView.tsx
@@ -13,6 +13,8 @@ type Props = {
 	play?: boolean
 	openable?: boolean
 	hideAdjustedPrice?: boolean
+	highlightAction?: boolean
+	highlightActionNoAnimation?: boolean
 }
 
 export const CardsView = ({
@@ -21,6 +23,8 @@ export const CardsView = ({
 	play = false,
 	openable = true,
 	hideAdjustedPrice,
+	highlightAction,
+	highlightActionNoAnimation,
 }: Props) => {
 	const theme = useTheme()
 	const dispatch = useAppDispatch()
@@ -103,6 +107,8 @@ export const CardsView = ({
 							state={play ? c : undefined}
 							fade={false}
 							hideAdjustedPrice={hideAdjustedPrice}
+							highlightAction={highlightAction}
+							highlightActionNoAnimation={highlightActionNoAnimation}
 						/>
 					</CV>
 				))}

--- a/client/src/pages/Game/pages/Table/components/Controls/components/TableButtons/components/ActionableButton.tsx
+++ b/client/src/pages/Game/pages/Table/components/Controls/components/TableButtons/components/ActionableButton.tsx
@@ -39,7 +39,14 @@ export const ActionableButton = ({ onClick }: Props) => {
 			onMouseOver={() => setOpened(true)}
 			onMouseLeave={() => setOpened(false)}
 		>
-			<CardsView cards={cards} play open={opened} hideAdjustedPrice />
+			<CardsView
+				cards={cards}
+				play
+				open={opened}
+				hideAdjustedPrice
+				highlightAction
+				highlightActionNoAnimation
+			/>
 		</CardsCounter>
 	)
 }

--- a/client/src/pages/Game/pages/Table/components/Controls/components/TableButtons/components/CorporationButton.tsx
+++ b/client/src/pages/Game/pages/Table/components/Controls/components/TableButtons/components/CorporationButton.tsx
@@ -15,10 +15,12 @@ export const CorporationButton = ({ onClick }: Props) => {
 	const player = usePlayerState()
 	const [opened, setOpened] = useState(false)
 
-	const corporation =
-		player.usedCards.length > 0
-			? CardsLookupApi.get(player.corporation || player.usedCards[0].code)
-			: undefined
+	const corporationState =
+		player.usedCards.length > 0 ? player.usedCards[0] : undefined
+
+	const corporation = corporationState
+		? CardsLookupApi.get(player.corporation || corporationState.code)
+		: undefined
 
 	const handleClick = () => {
 		onClick(CardType.Corporation)
@@ -36,7 +38,9 @@ export const CorporationButton = ({ onClick }: Props) => {
 				cards={[player.usedCards[0]]}
 				play
 				open={opened}
-				openable={false}
+				openable={
+					!corporationState?.played && corporation.playEffects.length > 0
+				}
 			/>
 		</Container>
 	) : (

--- a/client/src/pages/Game/pages/Table/components/Controls/components/TableButtons/components/EffectCards.tsx
+++ b/client/src/pages/Game/pages/Table/components/Controls/components/TableButtons/components/EffectCards.tsx
@@ -14,9 +14,14 @@ export const EffectCards = ({ onClick }: Props) => {
 
 	const cards = useMemo(
 		() =>
-			player.usedCards.filter(
-				(state) => CardsLookupApi.get(state.code).type === CardType.Effect,
-			),
+			player.usedCards.filter((state) => {
+				const info = CardsLookupApi.get(state.code)
+
+				return (
+					info.type === CardType.Effect ||
+					(info.type === CardType.Corporation && info.passiveEffects.length > 0)
+				)
+			}),
 		[player],
 	)
 
@@ -39,6 +44,8 @@ export const EffectCards = ({ onClick }: Props) => {
 				open={opened}
 				openable={false}
 				hideAdjustedPrice
+				highlightAction
+				highlightActionNoAnimation
 			/>
 		</CardsCounter>
 	)

--- a/shared/src/cards/effectsGrouped.ts
+++ b/shared/src/cards/effectsGrouped.ts
@@ -642,10 +642,11 @@ export const anyCardResourceChange = (
 				: [
 						condition({
 							description: `Player has to have a card that accepts ${res}`,
-							evaluate: ({ player }) =>
+							evaluate: ({ player, card }) =>
 								!!player.usedCards
 									.map((c) => ({ card: CardsLookupApi.get(c.code), state: c }))
-									.find(({ card }) => card.resource === res),
+									.find(({ card }) => card.resource === res) ||
+								CardsLookupApi.get(card.code).resource === res,
 						}),
 					],
 		description:

--- a/shared/src/game/player/actions/play-card.ts
+++ b/shared/src/game/player/actions/play-card.ts
@@ -51,6 +51,10 @@ export class PlayCardAction extends PlayerBaseAction<Args> {
 			throw new Error(`${card.code} isn't playable`)
 		}
 
+		if (card.actionEffects.length === 0) {
+			throw new Error(`${card.code} has no action effects`)
+		}
+
 		const ctx = {
 			player: this.player,
 			game: this.game,


### PR DESCRIPTION
## Describe your changes

 - when corporation is playable and player hovers over it, they can now just play it directly
 - corporations with effect are now shown in [Effects]
 - when evaluating if card resource action can be played, take the card itself into account
 - don't allow playing cards with no play effects

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests if possible
- [x] I adhere to best practices defined for this project
- [x] I adhere to code style defined for this project
