### PR TITLE
Fix free colony trade not working

### DIFF
--- a/client/src/pages/Game/pages/Table/Table.tsx
+++ b/client/src/pages/Game/pages/Table/Table.tsx
@@ -80,17 +80,19 @@ const Table = () => {
 				{pending?.type === PlayerActionType.BuildColony && (
 					<ColoniesModal
 						freeColonizePick
+						disableClose
 						allowDuplicateColonies={pending.data.allowMoreColoniesPerColony}
 						onClose={() => null}
 					/>
 				)}
 
 				{pending?.type === PlayerActionType.TradeWithColony && (
-					<ColoniesModal freeTradePick onClose={() => null} />
+					<ColoniesModal freeTradePick disableClose onClose={() => null} />
 				)}
 
 				{pending?.type === PlayerActionType.ChangeColonyStep && (
 					<ColoniesModal
+						disableClose
 						customAction={(index) => {
 							const colony = colonies[index]
 							const colonyInfo = ColoniesLookupApi.get(colony.code)

--- a/client/src/pages/Game/pages/Table/components/ColoniesModal/ColoniesModal.tsx
+++ b/client/src/pages/Game/pages/Table/components/ColoniesModal/ColoniesModal.tsx
@@ -5,6 +5,7 @@ type Props = {
 	freeTradePick?: boolean
 	freeColonizePick?: boolean
 	allowDuplicateColonies?: boolean
+	disableClose?: boolean
 	customAction?: (colonyIndex: number) => {
 		enabled: boolean
 		perform: () => void
@@ -18,10 +19,11 @@ export const ColoniesModal = ({
 	freeColonizePick,
 	allowDuplicateColonies,
 	customAction,
+	disableClose,
 	onClose,
 }: Props) => {
 	return (
-		<Modal header="Colonies" onClose={onClose} open>
+		<Modal header="Colonies" onClose={onClose} open hideClose={disableClose}>
 			<ColoniesList
 				freeTradePick={freeTradePick}
 				freeColonizePick={freeColonizePick}

--- a/client/src/pages/Game/pages/Table/components/ColoniesModal/components/ColonyDisplay.tsx
+++ b/client/src/pages/Game/pages/Table/components/ColoniesModal/components/ColonyDisplay.tsx
@@ -80,16 +80,17 @@ export const ColonyDisplay = ({
 
 	const canTradeWithAnyResource =
 		!noActions &&
-		(['money', 'titan', 'energy'] as const).some((res) =>
-			isOk(
-				canTradeWithColonyUsingResource({
-					player,
-					game,
-					colony,
-					resource: res,
-				}),
-			),
-		)
+		(freeTradePick ||
+			(['money', 'titan', 'energy'] as const).some((res) =>
+				isOk(
+					canTradeWithColonyUsingResource({
+						player,
+						game,
+						colony,
+						resource: res,
+					}),
+				),
+			))
 
 	const canColonize = noActions
 		? failure('')


### PR DESCRIPTION
## Describe your changes

The button was disabled when player couldn't affort it, even when the trade was supposed to be free

