### PR TITLE
Grouped events listing

### DIFF
--- a/client/src/components/TabsContent.tsx
+++ b/client/src/components/TabsContent.tsx
@@ -1,12 +1,15 @@
 import { ReactNode } from 'react'
 import styled from 'styled-components'
 
-type Props = {
-	tab: string
-	tabs: { content: ReactNode; key: string }[]
+type Props<TTab> = {
+	tab: TTab
+	tabs: { content: ReactNode; key: TTab }[]
 }
 
-export const TabsContent = ({ tab, tabs }: Props) => {
+export const TabsContent = <TTab extends string | number>({
+	tab,
+	tabs,
+}: Props<TTab>) => {
 	return <Content>{tabs.find(({ key }) => key === tab)?.content}</Content>
 }
 

--- a/client/src/components/TabsContent.tsx
+++ b/client/src/components/TabsContent.tsx
@@ -1,0 +1,16 @@
+import { ReactNode } from 'react'
+import styled from 'styled-components'
+
+type Props = {
+	tab: string
+	tabs: { content: ReactNode; key: string }[]
+}
+
+export const TabsContent = ({ tab, tabs }: Props) => {
+	return <Content>{tabs.find(({ key }) => key === tab)?.content}</Content>
+}
+
+const Content = styled.div`
+	flex: 1;
+	overflow: auto;
+`

--- a/client/src/components/TabsHead.tsx
+++ b/client/src/components/TabsHead.tsx
@@ -1,0 +1,52 @@
+import { darken } from 'polished'
+import { ReactNode } from 'react'
+import { css, styled } from 'styled-components'
+import { Box } from './Box'
+
+type Props = {
+	tab: string
+	setTab: (tab: string) => void
+	tabs: { title: ReactNode; key: string }[]
+	suffix?: ReactNode
+}
+
+export const TabsHead = ({ tab, tabs, setTab, suffix }: Props) => {
+	return (
+		<Head gap="0.25rem" align="flex-end">
+			{tabs.map(({ title, key }) => (
+				<Tab $active={key === tab} key={key} onClick={() => setTab(key)}>
+					{title}
+				</Tab>
+			))}
+			{suffix}
+		</Head>
+	)
+}
+
+const Head = styled(Box)`
+	background-color: ${({ theme }) => darken(0.05, theme.colors.background)};
+	padding: 0.25rem 0.5rem 0 0.5rem;
+	border-bottom: 2px solid ${({ theme }) => theme.colors.border};
+	flex-grow: 0;
+	flex-shrink: 0;
+`
+
+const Tab = styled.div<{ $active: boolean }>`
+	cursor: pointer;
+	padding: 0.5rem 1rem;
+	text-transform: uppercase;
+
+	${({ $active, theme }) => css`
+		background-color: ${$active
+			? theme.colors.border
+			: theme.colors.background};
+	`}
+
+	clip-path: polygon(
+				0 0,
+				calc(100% - 7px) 0,
+				100% 7px,
+				100% 100%,
+				0 100%
+			);
+`

--- a/client/src/components/TabsHead.tsx
+++ b/client/src/components/TabsHead.tsx
@@ -3,14 +3,19 @@ import { ReactNode } from 'react'
 import { css, styled } from 'styled-components'
 import { Box } from './Box'
 
-type Props = {
-	tab: string
-	setTab: (tab: string) => void
-	tabs: { title: ReactNode; key: string }[]
+type Props<TTab> = {
+	tab: TTab
+	setTab: (tab: TTab) => void
+	tabs: { title: ReactNode; key: TTab }[]
 	suffix?: ReactNode
 }
 
-export const TabsHead = ({ tab, tabs, setTab, suffix }: Props) => {
+export const TabsHead = <TTab extends string | number>({
+	tab,
+	tabs,
+	setTab,
+	suffix,
+}: Props<TTab>) => {
 	return (
 		<Head gap="0.25rem" align="flex-end">
 			{tabs.map(({ title, key }) => (

--- a/client/src/pages/Game/pages/Table/components/EventList/components/EventLine.tsx
+++ b/client/src/pages/Game/pages/Table/components/EventList/components/EventLine.tsx
@@ -1,11 +1,19 @@
 import { useGameModals } from '@/context/GameModalsContext'
 import { useLocale } from '@/context/LocaleContext'
-import { useAppStore } from '@/utils/hooks'
+import { setGameHighlightedCells } from '@/store/modules/game'
+import { formatTime } from '@/utils/formatTime'
+import { useAppDispatch, useAppStore } from '@/utils/hooks'
 import { faUser } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { CardsLookupApi, Resource } from '@shared/cards'
 import { Competitions } from '@shared/competitions'
-import { ColonyState, EventType, GameEvent, PlayerState } from '@shared/index'
+import {
+	ColonyState,
+	EventType,
+	GameEvent,
+	PlayerState,
+	TilePlaced,
+} from '@shared/index'
 import { Milestones } from '@shared/milestones'
 import { Projects } from '@shared/projects'
 import { otherToStr, tileToStr } from '@shared/texts'
@@ -18,7 +26,6 @@ import { memo, useEffect, useMemo, useRef } from 'react'
 import styled, { css, keyframes } from 'styled-components'
 import { CardResourceIcon } from '../../CardResourceIcon/CardResourceIcon'
 import { ResourceIcon } from '../../ResourceIcon/ResourceIcon'
-import { formatTime } from '@/utils/formatTime'
 
 type Props = {
 	event: GameEvent
@@ -32,6 +39,30 @@ const PlayerSpan = ({ player }: { player: PlayerState }) => (
 		{player?.name}
 	</span>
 )
+
+const TileSpan = ({ tile }: { tile: TilePlaced }) => {
+	const dispatch = useAppDispatch()
+
+	const handleMouseOver = () => {
+		dispatch(setGameHighlightedCells([tile.cell]))
+	}
+
+	const handleMouseOut = () => {
+		dispatch(setGameHighlightedCells([]))
+	}
+
+	return (
+		<span
+			style={{ color: '#91c8ff', cursor: 'pointer' }}
+			onClick={handleMouseOver}
+			onMouseOut={handleMouseOut}
+		>
+			{tile.other !== undefined && tile.other !== null
+				? otherToStr(tile.other)
+				: tileToStr(tile.tile)}
+		</span>
+	)
+}
 
 const PartySpan = ({ party }: { party: string }) => {
 	const locale = useLocale()
@@ -168,11 +199,7 @@ export const EventLine = ({ event, animated, onDone, timestamp }: Props) => {
 						{player && <PlayerSpan player={players[event.playerId]} />}
 						{!player && 'World government'}
 						{' placed '}
-						<CardSpanE>
-							{event.other !== undefined && event.other !== null
-								? otherToStr(event.other)
-								: tileToStr(event.tile)}
-						</CardSpanE>
+						<TileSpan tile={event} />
 					</>
 				)
 			case EventType.CompetitionSponsored:

--- a/client/src/pages/Game/pages/Table/components/EventList/components/EventLine.tsx
+++ b/client/src/pages/Game/pages/Table/components/EventList/components/EventLine.tsx
@@ -373,7 +373,7 @@ export const EventLine = ({ event, animated, onDone, timestamp }: Props) => {
 }
 
 const TimestampE = styled.span`
-	width: 3.4rem;
+	width: 4rem;
 	display: inline-block;
 	text-align: right;
 	margin-right: 0.25rem;

--- a/client/src/pages/Game/pages/Table/components/EventList/components/EventLine.tsx
+++ b/client/src/pages/Game/pages/Table/components/EventList/components/EventLine.tsx
@@ -18,6 +18,7 @@ import { memo, useEffect, useMemo, useRef } from 'react'
 import styled, { css, keyframes } from 'styled-components'
 import { CardResourceIcon } from '../../CardResourceIcon/CardResourceIcon'
 import { ResourceIcon } from '../../ResourceIcon/ResourceIcon'
+import { formatTime } from '@/utils/formatTime'
 
 type Props = {
 	event: GameEvent
@@ -75,14 +76,6 @@ const GlobalEventSpan = ({ eventCode }: { eventCode: string }) => {
 			</CardSpanE>
 		</>
 	)
-}
-
-const formatTime = (time: number) => {
-	const hours = Math.floor(time / 3600000)
-	const minutes = Math.floor((time % 3600000) / 60000)
-	const seconds = ((time % 60000) / 1000).toFixed(0)
-
-	return `${hours > 0 ? hours + ':' : ''}${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`
 }
 
 export const EventLine = ({ event, animated, onDone, timestamp }: Props) => {

--- a/client/src/pages/Game/pages/Table/components/EventList/components/EventsModal.tsx
+++ b/client/src/pages/Game/pages/Table/components/EventList/components/EventsModal.tsx
@@ -1,6 +1,15 @@
 import { Modal } from '@/components/Modal/Modal'
-import { EventLine } from './EventLine'
+import { TabsContent } from '@/components/TabsContent'
+import { TabsHead } from '@/components/TabsHead'
+import { faTimes } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { GameEvent } from '@shared/index'
+import { useState } from 'react'
+import { styled } from 'styled-components'
+import { InYourFaceEventModal } from '../../InYourFaceEventModal'
+import { EventLine } from './EventLine'
+import { GroupedEventsList } from './GroupedEventsList'
+import { useAppStore } from '@/utils/hooks'
 
 type Props = {
 	events: GameEvent[]
@@ -8,17 +17,85 @@ type Props = {
 }
 
 export const EventsModal = ({ onClose, events }: Props) => {
+	const [tab, setTab] = useState('all')
+	const [detail, setDetail] = useState<GameEvent>()
+
+	const highlighted = useAppStore(
+		(store) => store.game.highlightedCells.length > 0,
+	)
+
 	return (
 		<Modal
 			open={true}
-			contentStyle={{ minWidth: '500px' }}
+			contentStyle={{
+				minWidth: '600px',
+				maxWidth: '600px',
+			}}
+			backgroundStyle={highlighted ? { opacity: 0.1 } : undefined}
 			onClose={onClose}
-			header="Events"
+			bodyStyle={{
+				padding: 0,
+				display: 'flex',
+				flexDirection: 'column',
+				overflow: 'auto',
+			}}
 		>
-			{/* TODO: Windowed display mode to prevent lag */}
-			{[...events].reverse().map((e, i) => (
-				<EventLine key={i} event={e} animated={false} timestamp />
-			))}
+			<TabsHead
+				tab={tab}
+				setTab={setTab}
+				tabs={[
+					{ title: 'All', key: 'all' },
+					{ title: 'Grouped', key: 'grouped' },
+				]}
+				suffix={
+					<CloseButton>
+						<FontAwesomeIcon icon={faTimes} onClick={onClose} />
+					</CloseButton>
+				}
+			/>
+
+			<TabsContent
+				tab={tab}
+				tabs={[
+					{
+						key: 'all',
+						content: (
+							<EventsList>
+								{[...events].reverse().map((e, i) => (
+									<EventLine key={i} event={e} animated={false} timestamp />
+								))}
+							</EventsList>
+						),
+					},
+					{
+						key: 'grouped',
+						content: (
+							<EventsList>
+								<GroupedEventsList onClick={(e) => setDetail(e)} />
+							</EventsList>
+						),
+					},
+				]}
+			/>
+			{detail && (
+				<InYourFaceEventModal
+					event={detail}
+					onClose={() => setDetail(undefined)}
+				/>
+			)}
 		</Modal>
 	)
 }
+
+const EventsList = styled.div`
+	padding: 0.5rem;
+`
+
+const CloseButton = styled.div`
+	display: flex;
+	align-items: center;
+	padding: 0 0.5rem;
+	cursor: pointer;
+	margin-left: auto;
+	align-self: center;
+`

--- a/client/src/pages/Game/pages/Table/components/EventList/components/EventsModal.tsx
+++ b/client/src/pages/Game/pages/Table/components/EventList/components/EventsModal.tsx
@@ -1,6 +1,7 @@
 import { Modal } from '@/components/Modal/Modal'
 import { TabsContent } from '@/components/TabsContent'
 import { TabsHead } from '@/components/TabsHead'
+import { useAppStore } from '@/utils/hooks'
 import { faTimes } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { GameEvent } from '@shared/index'
@@ -9,15 +10,19 @@ import { styled } from 'styled-components'
 import { InYourFaceEventModal } from '../../InYourFaceEventModal'
 import { EventLine } from './EventLine'
 import { GroupedEventsList } from './GroupedEventsList'
-import { useAppStore } from '@/utils/hooks'
 
 type Props = {
 	events: GameEvent[]
 	onClose: () => void
 }
 
+enum Tabs {
+	ALL = 'all',
+	GROUPED = 'grouped',
+}
+
 export const EventsModal = ({ onClose, events }: Props) => {
-	const [tab, setTab] = useState('all')
+	const [tab, setTab] = useState(Tabs.ALL)
 	const [detail, setDetail] = useState<GameEvent>()
 
 	const highlighted = useAppStore(
@@ -44,8 +49,8 @@ export const EventsModal = ({ onClose, events }: Props) => {
 				tab={tab}
 				setTab={setTab}
 				tabs={[
-					{ title: 'All', key: 'all' },
-					{ title: 'Grouped', key: 'grouped' },
+					{ title: 'All', key: Tabs.ALL },
+					{ title: 'Grouped', key: Tabs.GROUPED },
 				]}
 				suffix={
 					<CloseButton>
@@ -58,7 +63,7 @@ export const EventsModal = ({ onClose, events }: Props) => {
 				tab={tab}
 				tabs={[
 					{
-						key: 'all',
+						key: Tabs.ALL,
 						content: (
 							<EventsList>
 								{[...events].reverse().map((e, i) => (
@@ -68,7 +73,7 @@ export const EventsModal = ({ onClose, events }: Props) => {
 						),
 					},
 					{
-						key: 'grouped',
+						key: Tabs.GROUPED,
 						content: (
 							<EventsList>
 								<GroupedEventsList onClick={(e) => setDetail(e)} />

--- a/client/src/pages/Game/pages/Table/components/EventList/components/EventsModal.tsx
+++ b/client/src/pages/Game/pages/Table/components/EventList/components/EventsModal.tsx
@@ -5,7 +5,7 @@ import { useAppStore } from '@/utils/hooks'
 import { faTimes } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { GameEvent } from '@shared/index'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { styled } from 'styled-components'
 import { InYourFaceEventModal } from '../../InYourFaceEventModal'
 import { EventLine } from './EventLine'
@@ -29,6 +29,32 @@ export const EventsModal = ({ onClose, events }: Props) => {
 		(store) => store.game.highlightedCells.length > 0,
 	)
 
+	const tabs = useMemo(
+		() => [
+			{
+				title: 'All',
+				key: Tabs.ALL,
+				content: (
+					<EventsList>
+						{[...events].reverse().map((e, i) => (
+							<EventLine key={i} event={e} animated={false} timestamp />
+						))}
+					</EventsList>
+				),
+			},
+			{
+				title: 'Grouped',
+				key: Tabs.GROUPED,
+				content: (
+					<EventsList>
+						<GroupedEventsList onClick={(e) => setDetail(e)} />
+					</EventsList>
+				),
+			},
+		],
+		[events],
+	)
+
 	return (
 		<Modal
 			open={true}
@@ -48,10 +74,7 @@ export const EventsModal = ({ onClose, events }: Props) => {
 			<TabsHead
 				tab={tab}
 				setTab={setTab}
-				tabs={[
-					{ title: 'All', key: Tabs.ALL },
-					{ title: 'Grouped', key: Tabs.GROUPED },
-				]}
+				tabs={tabs}
 				suffix={
 					<CloseButton>
 						<FontAwesomeIcon icon={faTimes} onClick={onClose} />
@@ -59,29 +82,8 @@ export const EventsModal = ({ onClose, events }: Props) => {
 				}
 			/>
 
-			<TabsContent
-				tab={tab}
-				tabs={[
-					{
-						key: Tabs.ALL,
-						content: (
-							<EventsList>
-								{[...events].reverse().map((e, i) => (
-									<EventLine key={i} event={e} animated={false} timestamp />
-								))}
-							</EventsList>
-						),
-					},
-					{
-						key: Tabs.GROUPED,
-						content: (
-							<EventsList>
-								<GroupedEventsList onClick={(e) => setDetail(e)} />
-							</EventsList>
-						),
-					},
-				]}
-			/>
+			<TabsContent tab={tab} tabs={tabs} />
+
 			{detail && (
 				<InYourFaceEventModal
 					event={detail}

--- a/client/src/pages/Game/pages/Table/components/EventList/components/GroupedEventsList.tsx
+++ b/client/src/pages/Game/pages/Table/components/EventList/components/GroupedEventsList.tsx
@@ -42,7 +42,7 @@ export const GroupedEventsList = ({ onClick }: Props) => {
 const Timestamp = styled.div`
 	width: 4rem;
 	text-align: right;
-	margin-right: 0.5rem;
+	margin-right: 0.25rem;
 `
 
 const Line = styled(Box)`

--- a/client/src/pages/Game/pages/Table/components/EventList/components/GroupedEventsList.tsx
+++ b/client/src/pages/Game/pages/Table/components/EventList/components/GroupedEventsList.tsx
@@ -6,6 +6,7 @@ import { useMemo } from 'react'
 import styled from 'styled-components'
 import { InYourFaceEventTitle } from '../../InYourFaceEvents/components/InYourFaceEventTitle'
 import { isInYourFaceEvent } from '../../InYourFaceEvents/utils/isInYourFaceEvent'
+import { lighten } from 'polished'
 
 type Props = {
 	onClick: (e: GameEvent) => void
@@ -47,4 +48,8 @@ const Timestamp = styled.div`
 
 const Line = styled(Box)`
 	cursor: pointer;
+
+	&:hover {
+		background-color: ${({ theme }) => lighten(0.1, theme.colors.background)};
+	}
 `

--- a/client/src/pages/Game/pages/Table/components/EventList/components/GroupedEventsList.tsx
+++ b/client/src/pages/Game/pages/Table/components/EventList/components/GroupedEventsList.tsx
@@ -1,0 +1,50 @@
+import { Box } from '@/components/Box'
+import { formatTime } from '@/utils/formatTime'
+import { useAppStore, useGameState, usePlayerState } from '@/utils/hooks'
+import { GameEvent } from '@shared/index'
+import { useMemo } from 'react'
+import styled from 'styled-components'
+import { InYourFaceEventTitle } from '../../InYourFaceEvents/components/InYourFaceEventTitle'
+import { isInYourFaceEvent } from '../../InYourFaceEvents/utils/isInYourFaceEvent'
+
+type Props = {
+	onClick: (e: GameEvent) => void
+}
+
+export const GroupedEventsList = ({ onClick }: Props) => {
+	const game = useGameState()
+	const player = usePlayerState()
+	const events = useAppStore((store) => store.game.events)
+
+	const allEvents = useMemo(
+		() =>
+			events.filter((event) => {
+				return (
+					(!('playerId' in event) || event.playerId !== player.id) &&
+					isInYourFaceEvent({ event })
+				)
+			}),
+		[events],
+	)
+
+	const allEventsReversed = useMemo(() => [...allEvents].reverse(), [allEvents])
+
+	const gameStart = new Date(game.started)
+
+	return allEventsReversed.map((e, i) => (
+		<Line key={i} onClick={() => onClick(e)}>
+			<Timestamp>{formatTime(e.t - gameStart.getTime())}</Timestamp>
+			<InYourFaceEventTitle event={e} />
+		</Line>
+	))
+}
+
+const Timestamp = styled.div`
+	width: 4rem;
+	text-align: right;
+	margin-right: 0.5rem;
+`
+
+const Line = styled(Box)`
+	cursor: pointer;
+`

--- a/client/src/pages/Game/pages/Table/components/InYourFaceEventModal.tsx
+++ b/client/src/pages/Game/pages/Table/components/InYourFaceEventModal.tsx
@@ -1,0 +1,26 @@
+import { Modal } from '@/components/Modal/Modal'
+import { GameEvent } from '@shared/index'
+import { InYourFaceEvent } from './InYourFaceEvents/components/InYourFaceEvent'
+import { useAppStore } from '@/utils/hooks'
+
+type Props = {
+	event: GameEvent
+	onClose: () => void
+}
+
+export const InYourFaceEventModal = ({ event, onClose }: Props) => {
+	const highlighted = useAppStore(
+		(store) => store.game.highlightedCells.length > 0,
+	)
+
+	return (
+		<Modal
+			header={<></>}
+			open={true}
+			onClose={onClose}
+			backgroundStyle={highlighted ? { opacity: 0.1 } : undefined}
+		>
+			<InYourFaceEvent event={event} />
+		</Modal>
+	)
+}

--- a/client/src/pages/Game/pages/Table/components/InYourFaceEvents/InYourFaceEvents.tsx
+++ b/client/src/pages/Game/pages/Table/components/InYourFaceEvents/InYourFaceEvents.tsx
@@ -1,18 +1,17 @@
 import { Button, Portal } from '@/components'
 import { ClippedBox } from '@/components/ClippedBox'
 import { Flex } from '@/components/Flex/Flex'
-import { useLocale } from '@/context/LocaleContext'
 import { useAppStore, useToggle } from '@/utils/hooks'
 import { useGameEventsHandler } from '@/utils/useGameEventsHandler'
 import { faBell, faChevronDown } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { EventType, GameEvent } from '@shared/index'
+import { GameEvent } from '@shared/index'
 import { useCallback, useEffect, useState } from 'react'
 import styled, { css, keyframes } from 'styled-components'
 import { InYourFaceEvent } from './components/InYourFaceEvent'
-import { PlayerDidHeader } from './components/PlayerDidHeader'
-import { isInYourFaceEvent } from './utils/isInYourFaceEvent'
 import { InYourFaceEventsList } from './components/InYourFaceEventsList'
+import { InYourFaceEventTitle } from './components/InYourFaceEventTitle'
+import { isInYourFaceEvent } from './utils/isInYourFaceEvent'
 
 export const InYourFaceEvents = () => {
 	const player = useAppStore((state) => state.game.player)
@@ -25,8 +24,6 @@ export const InYourFaceEvents = () => {
 	const [rendered, setRendered] = useState(false)
 	const [events, setEvents] = useState<GameEvent[]>([])
 	const [showList, toggleList] = useToggle()
-
-	const t = useLocale()
 
 	const current = events[0]
 
@@ -49,111 +46,6 @@ export const InYourFaceEvents = () => {
 			setRendered(true)
 		}
 	}, [shown])
-
-	const renderEventHead = useCallback((event: GameEvent) => {
-		switch (event.type) {
-			case EventType.CardPlayed:
-				return (
-					<PlayerDidHeader
-						noSpacing
-						playerId={event.playerId}
-						thing=" played card"
-					/>
-				)
-			case EventType.CardUsed:
-				return (
-					<PlayerDidHeader
-						noSpacing
-						playerId={event.playerId}
-						thing=" used card"
-					/>
-				)
-			case EventType.CompetitionSponsored:
-				return (
-					<PlayerDidHeader
-						noSpacing
-						playerId={event.playerId}
-						thing=" sponsored competition"
-					/>
-				)
-			case EventType.MilestoneBought:
-				return (
-					<PlayerDidHeader
-						noSpacing
-						playerId={event.playerId}
-						thing=" bought milestone"
-					/>
-				)
-			case EventType.ColonyBuilt:
-				return (
-					<PlayerDidHeader
-						noSpacing
-						playerId={event.playerId}
-						thing=" built colony"
-					/>
-				)
-			case EventType.ColonyTrading:
-				return (
-					<PlayerDidHeader
-						noSpacing
-						playerId={event.playerId}
-						thing=" traded with colony"
-					/>
-				)
-			case EventType.StandardProjectBought:
-				return (
-					<PlayerDidHeader
-						playerId={event.playerId}
-						noSpacing
-						thing=" bought standard project"
-					/>
-				)
-			case EventType.StartingSetup:
-				return (
-					<PlayerDidHeader
-						playerId={event.playerId}
-						noSpacing
-						thing=" picked their starting setup"
-					/>
-				)
-			case EventType.TilePlaced:
-				return (
-					<PlayerDidHeader
-						playerId={event.playerId}
-						noSpacing
-						thing=" placed tile"
-					/>
-				)
-			case EventType.ProductionDone:
-				return <CenterText>Production</CenterText>
-			case EventType.MarsTerraformed:
-				return <CenterText>Mars terraformed</CenterText>
-			case EventType.GlobalEventsChanged:
-				return <CenterText>Global events changed</CenterText>
-			case EventType.CurrentGlobalEventExecuted:
-				return <CenterText>Global event executed</CenterText>
-			case EventType.NewGovernment:
-				return <CenterText>New government</CenterText>
-			case EventType.PlayerMovedDelegate:
-				return (
-					<PlayerDidHeader
-						playerId={event.playerId}
-						noSpacing
-						thing={` added delegate to ${t.committeeParties[event.partyCode]}`}
-					/>
-				)
-			case EventType.CommitteePartyActivePolicyActivated:
-				return (
-					<PlayerDidHeader
-						playerId={event.playerId}
-						noSpacing
-						thing=" used ruling policy"
-					/>
-				)
-			default:
-				return null
-		}
-	}, [])
 
 	const handleDismiss = useCallback(() => {
 		setEvents((events) => events.slice(1))
@@ -206,7 +98,7 @@ export const InYourFaceEvents = () => {
 												marginRight: `${(indexReversed + 1) * 0.5}rem`,
 											}}
 										>
-											{renderEventHead(e)}
+											<InYourFaceEventTitle event={e} />
 										</NextEvent>
 									)
 								})}
@@ -331,10 +223,6 @@ const NextEvents = styled.div`
 	position: absolute;
 	margin-top: -1rem;
 	width: 30rem;
-`
-
-const CenterText = styled.div`
-	text-align: center;
 `
 
 const MinimizedButton = styled(Button)`

--- a/client/src/pages/Game/pages/Table/components/InYourFaceEvents/components/InYourFaceEvent.tsx
+++ b/client/src/pages/Game/pages/Table/components/InYourFaceEvents/components/InYourFaceEvent.tsx
@@ -1,0 +1,65 @@
+import { EventType, GameEvent } from '@shared/index'
+import { useCallback } from 'react'
+import { CardPlayedEvent } from './CardPlayedEvent'
+import { CardUsedEvent } from './CardUsedEvent'
+import { ColonyBuiltEvent } from './ColonyBuiltEvent'
+import { ColonyTradingEvent } from './ColonyTradingEvent'
+import { CommitteePartyActivePolicyActivatedEvent } from './CommitteePartyActivePolicyActivatedEvent'
+import { CompetitionSponsoredEvent } from './CompetitionSponsoredEvent'
+import { CurrentGlobalEventExecutedEvent } from './CurrentGlobalEventExecuted'
+import { GlobalEventsChangedEvent } from './GlobalEventsChangedEvent'
+import { MarsTerraformedEvent } from './MarsTerraformedEvent'
+import { MilestoneBoughtEvent } from './MilestoneBoughtEvent'
+import { NewGovernmentEvent } from './NewGovernmentEvent'
+import { PlayerMovedDelegateEvent } from './PlayerMovedDelegateEvent'
+import { ProductionDoneEvent } from './ProductionDoneEvent'
+import { StandardProjectBoughtEvent } from './StandardProjectBoughtEvent'
+import { StartingSetupEvent } from './StartingSetupEvent'
+import { TilePlacedEvent } from './TilePlacedEvent'
+
+type Props = {
+	event: GameEvent
+}
+
+export const InYourFaceEvent = ({ event }: Props) => {
+	const renderEvent = useCallback((event: GameEvent) => {
+		switch (event.type) {
+			case EventType.CardPlayed:
+				return <CardPlayedEvent event={event} />
+			case EventType.CardUsed:
+				return <CardUsedEvent event={event} />
+			case EventType.StandardProjectBought:
+				return <StandardProjectBoughtEvent event={event} />
+			case EventType.MilestoneBought:
+				return <MilestoneBoughtEvent event={event} />
+			case EventType.CompetitionSponsored:
+				return <CompetitionSponsoredEvent event={event} />
+			case EventType.ColonyBuilt:
+				return <ColonyBuiltEvent event={event} />
+			case EventType.ColonyTrading:
+				return <ColonyTradingEvent event={event} />
+			case EventType.StartingSetup:
+				return <StartingSetupEvent event={event} />
+			case EventType.ProductionDone:
+				return <ProductionDoneEvent event={event} />
+			case EventType.TilePlaced:
+				return <TilePlacedEvent event={event} />
+			case EventType.MarsTerraformed:
+				return <MarsTerraformedEvent />
+			case EventType.GlobalEventsChanged:
+				return <GlobalEventsChangedEvent event={event} />
+			case EventType.CurrentGlobalEventExecuted:
+				return <CurrentGlobalEventExecutedEvent event={event} />
+			case EventType.NewGovernment:
+				return <NewGovernmentEvent event={event} />
+			case EventType.PlayerMovedDelegate:
+				return <PlayerMovedDelegateEvent event={event} />
+			case EventType.CommitteePartyActivePolicyActivated:
+				return <CommitteePartyActivePolicyActivatedEvent event={event} />
+			default:
+				return null
+		}
+	}, [])
+
+	return renderEvent(event)
+}

--- a/client/src/pages/Game/pages/Table/components/InYourFaceEvents/components/InYourFaceEventTitle.tsx
+++ b/client/src/pages/Game/pages/Table/components/InYourFaceEvents/components/InYourFaceEventTitle.tsx
@@ -1,7 +1,10 @@
-import { EventType, GameEvent } from '@shared/index'
+import { EventType, GameEvent, GridCellContent } from '@shared/index'
 import { PlayerDidHeader } from './PlayerDidHeader'
 import { styled } from 'styled-components'
 import { useLocale } from '@/context/LocaleContext'
+import { Competitions } from '@shared/competitions'
+import { Milestones } from '@shared/milestones'
+import { Projects } from '@shared/projects'
 
 type Props = {
 	event: GameEvent
@@ -16,7 +19,7 @@ export const InYourFaceEventTitle = ({ event }: Props) => {
 				<PlayerDidHeader
 					noSpacing
 					playerId={event.playerId}
-					thing=" played card"
+					thing={` played ${t.cards[event.card]}`}
 				/>
 			)
 		case EventType.CardUsed:
@@ -24,7 +27,7 @@ export const InYourFaceEventTitle = ({ event }: Props) => {
 				<PlayerDidHeader
 					noSpacing
 					playerId={event.playerId}
-					thing=" used card"
+					thing={` used ${t.cards[event.card]}`}
 				/>
 			)
 		case EventType.CompetitionSponsored:
@@ -32,7 +35,7 @@ export const InYourFaceEventTitle = ({ event }: Props) => {
 				<PlayerDidHeader
 					noSpacing
 					playerId={event.playerId}
-					thing=" sponsored competition"
+					thing={` sponsored ${Competitions[event.competition].title} competition`}
 				/>
 			)
 		case EventType.MilestoneBought:
@@ -40,7 +43,7 @@ export const InYourFaceEventTitle = ({ event }: Props) => {
 				<PlayerDidHeader
 					noSpacing
 					playerId={event.playerId}
-					thing=" bought milestone"
+					thing={` bought ${Milestones[event.milestone].title} milestone`}
 				/>
 			)
 		case EventType.ColonyBuilt:
@@ -48,7 +51,7 @@ export const InYourFaceEventTitle = ({ event }: Props) => {
 				<PlayerDidHeader
 					noSpacing
 					playerId={event.playerId}
-					thing=" built colony"
+					thing={` built colony on ${t.colonies[event.colony]}`}
 				/>
 			)
 		case EventType.ColonyTrading:
@@ -56,7 +59,7 @@ export const InYourFaceEventTitle = ({ event }: Props) => {
 				<PlayerDidHeader
 					noSpacing
 					playerId={event.playerId}
-					thing=" traded with colony"
+					thing={` traded with ${t.colonies[event.colony]} colony`}
 				/>
 			)
 		case EventType.StandardProjectBought:
@@ -64,7 +67,7 @@ export const InYourFaceEventTitle = ({ event }: Props) => {
 				<PlayerDidHeader
 					playerId={event.playerId}
 					noSpacing
-					thing=" bought standard project"
+					thing={` bought ${Projects[event.project].description} project`}
 				/>
 			)
 		case EventType.StartingSetup:
@@ -80,7 +83,7 @@ export const InYourFaceEventTitle = ({ event }: Props) => {
 				<PlayerDidHeader
 					playerId={event.playerId}
 					noSpacing
-					thing=" placed tile"
+					thing={` placed ${GridCellContent[event.tile]} tile`}
 				/>
 			)
 		case EventType.ProductionDone:

--- a/client/src/pages/Game/pages/Table/components/InYourFaceEvents/components/InYourFaceEventTitle.tsx
+++ b/client/src/pages/Game/pages/Table/components/InYourFaceEvents/components/InYourFaceEventTitle.tsx
@@ -1,0 +1,119 @@
+import { EventType, GameEvent } from '@shared/index'
+import { PlayerDidHeader } from './PlayerDidHeader'
+import { styled } from 'styled-components'
+import { useLocale } from '@/context/LocaleContext'
+
+type Props = {
+	event: GameEvent
+}
+
+export const InYourFaceEventTitle = ({ event }: Props) => {
+	const t = useLocale()
+
+	switch (event.type) {
+		case EventType.CardPlayed:
+			return (
+				<PlayerDidHeader
+					noSpacing
+					playerId={event.playerId}
+					thing=" played card"
+				/>
+			)
+		case EventType.CardUsed:
+			return (
+				<PlayerDidHeader
+					noSpacing
+					playerId={event.playerId}
+					thing=" used card"
+				/>
+			)
+		case EventType.CompetitionSponsored:
+			return (
+				<PlayerDidHeader
+					noSpacing
+					playerId={event.playerId}
+					thing=" sponsored competition"
+				/>
+			)
+		case EventType.MilestoneBought:
+			return (
+				<PlayerDidHeader
+					noSpacing
+					playerId={event.playerId}
+					thing=" bought milestone"
+				/>
+			)
+		case EventType.ColonyBuilt:
+			return (
+				<PlayerDidHeader
+					noSpacing
+					playerId={event.playerId}
+					thing=" built colony"
+				/>
+			)
+		case EventType.ColonyTrading:
+			return (
+				<PlayerDidHeader
+					noSpacing
+					playerId={event.playerId}
+					thing=" traded with colony"
+				/>
+			)
+		case EventType.StandardProjectBought:
+			return (
+				<PlayerDidHeader
+					playerId={event.playerId}
+					noSpacing
+					thing=" bought standard project"
+				/>
+			)
+		case EventType.StartingSetup:
+			return (
+				<PlayerDidHeader
+					playerId={event.playerId}
+					noSpacing
+					thing=" picked their starting setup"
+				/>
+			)
+		case EventType.TilePlaced:
+			return (
+				<PlayerDidHeader
+					playerId={event.playerId}
+					noSpacing
+					thing=" placed tile"
+				/>
+			)
+		case EventType.ProductionDone:
+			return <CenterText>Production</CenterText>
+		case EventType.MarsTerraformed:
+			return <CenterText>Mars terraformed</CenterText>
+		case EventType.GlobalEventsChanged:
+			return <CenterText>Global events changed</CenterText>
+		case EventType.CurrentGlobalEventExecuted:
+			return <CenterText>Global event executed</CenterText>
+		case EventType.NewGovernment:
+			return <CenterText>New government</CenterText>
+		case EventType.PlayerMovedDelegate:
+			return (
+				<PlayerDidHeader
+					playerId={event.playerId}
+					noSpacing
+					thing={` added delegate to ${t.committeeParties[event.partyCode]}`}
+				/>
+			)
+		case EventType.CommitteePartyActivePolicyActivated:
+			return (
+				<PlayerDidHeader
+					playerId={event.playerId}
+					noSpacing
+					thing=" used ruling policy"
+				/>
+			)
+		default:
+			return null
+	}
+}
+
+const CenterText = styled.div`
+	text-align: center;
+`

--- a/client/src/pages/Game/pages/Table/components/InYourFaceEvents/components/InYourFaceEventTitle.tsx
+++ b/client/src/pages/Game/pages/Table/components/InYourFaceEvents/components/InYourFaceEventTitle.tsx
@@ -1,10 +1,11 @@
-import { EventType, GameEvent, GridCellContent } from '@shared/index'
-import { PlayerDidHeader } from './PlayerDidHeader'
-import { styled } from 'styled-components'
 import { useLocale } from '@/context/LocaleContext'
 import { Competitions } from '@shared/competitions'
+import { EventType, GameEvent } from '@shared/index'
 import { Milestones } from '@shared/milestones'
 import { Projects } from '@shared/projects'
+import { otherToStr, tileToStr } from '@shared/texts'
+import { styled } from 'styled-components'
+import { PlayerDidHeader } from './PlayerDidHeader'
 
 type Props = {
 	event: GameEvent
@@ -83,7 +84,11 @@ export const InYourFaceEventTitle = ({ event }: Props) => {
 				<PlayerDidHeader
 					playerId={event.playerId}
 					noSpacing
-					thing={` placed ${GridCellContent[event.tile]} tile`}
+					thing={` placed ${
+						event.other !== undefined && event.other !== null
+							? otherToStr(event.other)
+							: tileToStr(event.tile)
+					} tile`}
 				/>
 			)
 		case EventType.ProductionDone:

--- a/client/src/pages/Game/pages/Table/components/InYourFaceEvents/components/InYourFaceEventTitle.tsx
+++ b/client/src/pages/Game/pages/Table/components/InYourFaceEvents/components/InYourFaceEventTitle.tsx
@@ -6,6 +6,7 @@ import { Projects } from '@shared/projects'
 import { otherToStr, tileToStr } from '@shared/texts'
 import { styled } from 'styled-components'
 import { PlayerDidHeader } from './PlayerDidHeader'
+import { useGameState } from '@/utils/hooks'
 
 type Props = {
 	event: GameEvent
@@ -13,6 +14,7 @@ type Props = {
 
 export const InYourFaceEventTitle = ({ event }: Props) => {
 	const t = useLocale()
+	const game = useGameState()
 
 	switch (event.type) {
 		case EventType.CardPlayed:
@@ -52,7 +54,7 @@ export const InYourFaceEventTitle = ({ event }: Props) => {
 				<PlayerDidHeader
 					noSpacing
 					playerId={event.playerId}
-					thing={` built colony on ${t.colonies[event.colony]}`}
+					thing={` built colony on ${t.colonies[game.colonies[event.colony].code]}`}
 				/>
 			)
 		case EventType.ColonyTrading:
@@ -60,7 +62,7 @@ export const InYourFaceEventTitle = ({ event }: Props) => {
 				<PlayerDidHeader
 					noSpacing
 					playerId={event.playerId}
-					thing={` traded with ${t.colonies[event.colony]} colony`}
+					thing={` traded with ${t.colonies[game.colonies[event.colony].code]} colony`}
 				/>
 			)
 		case EventType.StandardProjectBought:

--- a/client/src/pages/Game/pages/Table/components/InYourFaceEvents/components/InYourFaceEventsList.tsx
+++ b/client/src/pages/Game/pages/Table/components/InYourFaceEvents/components/InYourFaceEventsList.tsx
@@ -78,7 +78,7 @@ export const InYourFaceEventsList = ({ onClose }: Props) => {
 
 			{listMode &&
 				allEventsReversed.map((e, i) => (
-					<Box
+					<Line
 						key={i}
 						onClick={() => {
 							setIndex(allEvents.length - 1 - i)
@@ -87,7 +87,7 @@ export const InYourFaceEventsList = ({ onClose }: Props) => {
 					>
 						<Timestamp>{formatTime(e.t - gameStart.getTime())}</Timestamp>
 						<InYourFaceEventTitle event={e} />
-					</Box>
+					</Line>
 				))}
 		</Modal>
 	)
@@ -97,4 +97,8 @@ const Timestamp = styled.div`
 	width: 4rem;
 	text-align: right;
 	margin-right: 0.5rem;
+`
+
+const Line = styled(Box)`
+	cursor: pointer;
 `

--- a/client/src/pages/Game/pages/Table/components/InYourFaceEvents/components/InYourFaceEventsList.tsx
+++ b/client/src/pages/Game/pages/Table/components/InYourFaceEvents/components/InYourFaceEventsList.tsx
@@ -1,0 +1,54 @@
+import { Button } from '@/components'
+import { Box } from '@/components/Box'
+import { Flex } from '@/components/Flex/Flex'
+import { Modal } from '@/components/Modal/Modal'
+import { useAppStore, usePlayerState } from '@/utils/hooks'
+import { useMemo, useState } from 'react'
+import { isInYourFaceEvent } from '../utils/isInYourFaceEvent'
+import { InYourFaceEvent } from './InYourFaceEvent'
+
+type Props = {
+	onClose: () => void
+}
+
+export const InYourFaceEventsList = ({ onClose }: Props) => {
+	const player = usePlayerState()
+	const events = useAppStore((store) => store.game.events)
+
+	const allEvents = useMemo(
+		() =>
+			events.filter((event) => {
+				return (
+					(!('playerId' in event) || event.playerId !== player.id) &&
+					isInYourFaceEvent({ event })
+				)
+			}),
+		[events],
+	)
+
+	const [index, setIndex] = useState(allEvents.length - 1)
+
+	return (
+		<Modal onClose={onClose} open>
+			<Box gap="0.5rem" $mb={4} style={{ minWidth: '30rem' }} justify="center">
+				<Button
+					onClick={() => setIndex((prev) => (prev > 0 ? prev - 1 : prev))}
+				>
+					Prev
+				</Button>
+				{index + 1} / {allEvents.length}
+				<Button
+					onClick={() =>
+						setIndex((prev) => (prev < allEvents.length - 2 ? prev + 1 : prev))
+					}
+				>
+					Next
+				</Button>
+			</Box>
+
+			<Flex direction="column">
+				<InYourFaceEvent key={index} event={allEvents[index]} />
+			</Flex>
+		</Modal>
+	)
+}

--- a/client/src/pages/Game/pages/Table/components/InYourFaceEvents/components/InYourFaceEventsList.tsx
+++ b/client/src/pages/Game/pages/Table/components/InYourFaceEvents/components/InYourFaceEventsList.tsx
@@ -2,24 +2,31 @@ import { Button } from '@/components'
 import { Box } from '@/components/Box'
 import { Flex } from '@/components/Flex/Flex'
 import { Modal } from '@/components/Modal/Modal'
-import { formatTime } from '@/utils/formatTime'
-import { useAppStore, useGameState, usePlayerState } from '@/utils/hooks'
+import { useAppStore, usePlayerState } from '@/utils/hooks'
+import {
+	faChevronLeft,
+	faChevronRight,
+	faList,
+} from '@fortawesome/free-solid-svg-icons'
+import { GameEvent } from '@shared/index'
 import { useMemo, useState } from 'react'
-import styled from 'styled-components'
+import { GroupedEventsList } from '../../EventList/components/GroupedEventsList'
+import { InYourFaceEventModal } from '../../InYourFaceEventModal'
 import { isInYourFaceEvent } from '../utils/isInYourFaceEvent'
 import { InYourFaceEvent } from './InYourFaceEvent'
-import { InYourFaceEventTitle } from './InYourFaceEventTitle'
+import { styled } from 'styled-components'
 
 type Props = {
 	onClose: () => void
 }
 
 export const InYourFaceEventsList = ({ onClose }: Props) => {
-	const game = useGameState()
 	const player = usePlayerState()
 	const events = useAppStore((store) => store.game.events)
 
-	const [listMode, setListMode] = useState(false)
+	const highlight = useAppStore(
+		(store) => store.game.highlightedCells.length > 0,
+	)
 
 	const allEvents = useMemo(
 		() =>
@@ -32,43 +39,53 @@ export const InYourFaceEventsList = ({ onClose }: Props) => {
 		[events],
 	)
 
-	const allEventsReversed = useMemo(() => [...allEvents].reverse(), [allEvents])
-
+	const [listMode, setListMode] = useState(false)
 	const [index, setIndex] = useState(allEvents.length - 1)
-
-	const gameStart = new Date(game.started)
+	const [detail, setDetail] = useState<GameEvent>()
 
 	return (
 		<Modal
 			header={'Events history'}
 			onClose={onClose}
 			open
-			bodyStyle={{ minWidth: '30rem' }}
+			bodyStyle={{
+				minWidth: '30rem',
+				display: 'flex',
+				flexDirection: 'column',
+				overflow: 'auto',
+			}}
+			backgroundStyle={highlight ? { opacity: 0.1 } : undefined}
 		>
-			{!listMode && (
-				<Box $mb={4}>
-					<Box>
-						<Button onClick={() => setListMode(true)}>Show list</Button>
-					</Box>
-					<Box gap="0.5rem" $ml="auto" justify="center">
-						<Button
-							onClick={() => setIndex((prev) => (prev > 0 ? prev - 1 : prev))}
-						>
-							Prev
-						</Button>
-						{index + 1} / {allEvents.length}
-						<Button
-							onClick={() =>
-								setIndex((prev) =>
-									prev < allEvents.length - 1 ? prev + 1 : prev,
-								)
-							}
-						>
-							Next
-						</Button>
-					</Box>
-				</Box>
-			)}
+			<Head $mb={2}>
+				{!listMode && (
+					<>
+						<Box>
+							<Button onClick={() => setListMode(true)} icon={faList}>
+								Show list
+							</Button>
+						</Box>
+						<Box gap="0.5rem" $ml="auto" justify="center">
+							<Button
+								onClick={() => setIndex((prev) => (prev > 0 ? prev - 1 : prev))}
+								icon={faChevronLeft}
+							/>
+							{index + 1} / {allEvents.length}
+							<Button
+								onClick={() =>
+									setIndex((prev) =>
+										prev < allEvents.length - 1 ? prev + 1 : prev,
+									)
+								}
+								icon={faChevronRight}
+							/>
+						</Box>
+					</>
+				)}
+
+				{listMode && (
+					<Button onClick={() => setListMode(false)}>Show events</Button>
+				)}
+			</Head>
 
 			{!listMode && (
 				<Flex direction="column">
@@ -76,29 +93,28 @@ export const InYourFaceEventsList = ({ onClose }: Props) => {
 				</Flex>
 			)}
 
-			{listMode &&
-				allEventsReversed.map((e, i) => (
-					<Line
-						key={i}
-						onClick={() => {
-							setIndex(allEvents.length - 1 - i)
-							setListMode(false)
-						}}
-					>
-						<Timestamp>{formatTime(e.t - gameStart.getTime())}</Timestamp>
-						<InYourFaceEventTitle event={e} />
-					</Line>
-				))}
+			{listMode && (
+				<Content>
+					<GroupedEventsList onClick={(e) => setDetail(e)} />
+				</Content>
+			)}
+
+			{detail && (
+				<InYourFaceEventModal
+					event={detail}
+					onClose={() => setDetail(undefined)}
+				/>
+			)}
 		</Modal>
 	)
 }
 
-const Timestamp = styled.div`
-	width: 4rem;
-	text-align: right;
-	margin-right: 0.5rem;
+const Content = styled.div`
+	flex: 1;
+	overflow: auto;
 `
 
-const Line = styled(Box)`
-	cursor: pointer;
+const Head = styled(Box)`
+	flex-grow: 0;
+	flex-shrink: 0;
 `

--- a/client/src/pages/Game/pages/Table/components/InYourFaceEvents/components/InYourFaceEventsList.tsx
+++ b/client/src/pages/Game/pages/Table/components/InYourFaceEvents/components/InYourFaceEventsList.tsx
@@ -2,18 +2,24 @@ import { Button } from '@/components'
 import { Box } from '@/components/Box'
 import { Flex } from '@/components/Flex/Flex'
 import { Modal } from '@/components/Modal/Modal'
-import { useAppStore, usePlayerState } from '@/utils/hooks'
+import { formatTime } from '@/utils/formatTime'
+import { useAppStore, useGameState, usePlayerState } from '@/utils/hooks'
 import { useMemo, useState } from 'react'
+import styled from 'styled-components'
 import { isInYourFaceEvent } from '../utils/isInYourFaceEvent'
 import { InYourFaceEvent } from './InYourFaceEvent'
+import { InYourFaceEventTitle } from './InYourFaceEventTitle'
 
 type Props = {
 	onClose: () => void
 }
 
 export const InYourFaceEventsList = ({ onClose }: Props) => {
+	const game = useGameState()
 	const player = usePlayerState()
 	const events = useAppStore((store) => store.game.events)
+
+	const [listMode, setListMode] = useState(false)
 
 	const allEvents = useMemo(
 		() =>
@@ -26,29 +32,69 @@ export const InYourFaceEventsList = ({ onClose }: Props) => {
 		[events],
 	)
 
+	const allEventsReversed = useMemo(() => [...allEvents].reverse(), [allEvents])
+
 	const [index, setIndex] = useState(allEvents.length - 1)
 
-	return (
-		<Modal onClose={onClose} open>
-			<Box gap="0.5rem" $mb={4} style={{ minWidth: '30rem' }} justify="center">
-				<Button
-					onClick={() => setIndex((prev) => (prev > 0 ? prev - 1 : prev))}
-				>
-					Prev
-				</Button>
-				{index + 1} / {allEvents.length}
-				<Button
-					onClick={() =>
-						setIndex((prev) => (prev < allEvents.length - 2 ? prev + 1 : prev))
-					}
-				>
-					Next
-				</Button>
-			</Box>
+	const gameStart = new Date(game.started)
 
-			<Flex direction="column">
-				<InYourFaceEvent key={index} event={allEvents[index]} />
-			</Flex>
+	return (
+		<Modal
+			header={'Events history'}
+			onClose={onClose}
+			open
+			bodyStyle={{ minWidth: '30rem' }}
+		>
+			{!listMode && (
+				<Box $mb={4}>
+					<Box>
+						<Button onClick={() => setListMode(true)}>Show list</Button>
+					</Box>
+					<Box gap="0.5rem" $ml="auto" justify="center">
+						<Button
+							onClick={() => setIndex((prev) => (prev > 0 ? prev - 1 : prev))}
+						>
+							Prev
+						</Button>
+						{index + 1} / {allEvents.length}
+						<Button
+							onClick={() =>
+								setIndex((prev) =>
+									prev < allEvents.length - 1 ? prev + 1 : prev,
+								)
+							}
+						>
+							Next
+						</Button>
+					</Box>
+				</Box>
+			)}
+
+			{!listMode && (
+				<Flex direction="column">
+					<InYourFaceEvent key={index} event={allEvents[index]} />
+				</Flex>
+			)}
+
+			{listMode &&
+				allEventsReversed.map((e, i) => (
+					<Box
+						key={i}
+						onClick={() => {
+							setIndex(allEvents.length - 1 - i)
+							setListMode(false)
+						}}
+					>
+						<Timestamp>{formatTime(e.t - gameStart.getTime())}</Timestamp>
+						<InYourFaceEventTitle event={e} />
+					</Box>
+				))}
 		</Modal>
 	)
 }
+
+const Timestamp = styled.div`
+	width: 4rem;
+	text-align: right;
+	margin-right: 0.5rem;
+`

--- a/client/src/pages/Game/pages/Table/components/InYourFaceEvents/components/PlayerDidHeader.tsx
+++ b/client/src/pages/Game/pages/Table/components/InYourFaceEvents/components/PlayerDidHeader.tsx
@@ -1,6 +1,7 @@
 import { useAppStore } from '@/utils/hooks'
 import { ReactNode } from 'react'
 import { SomethingHappenedHeader } from './SomethingHappenedHeader'
+import { lighten } from 'polished'
 
 type Props = {
 	playerId: number
@@ -18,7 +19,13 @@ export const PlayerDidHeader = ({ playerId, thing, noSpacing }: Props) => {
 
 	return (
 		<SomethingHappenedHeader $noSpacing={noSpacing}>
-			<span style={{ color: player?.color }}>{displayName}</span>
+			<span
+				style={{
+					color: player?.color ? lighten(0.2, player.color) : undefined,
+				}}
+			>
+				{displayName}
+			</span>
 			{thing}
 		</SomethingHappenedHeader>
 	)

--- a/client/src/pages/Game/pages/Table/components/InYourFaceEvents/utils/isInYourFaceEvent.ts
+++ b/client/src/pages/Game/pages/Table/components/InYourFaceEvents/utils/isInYourFaceEvent.ts
@@ -1,0 +1,32 @@
+import { EventType, GameEvent } from '@shared/index'
+
+type Params = {
+	event: GameEvent
+}
+
+const PROCESSABLE_EVENTS = [
+	EventType.CardPlayed,
+	EventType.CardUsed,
+	EventType.StandardProjectBought,
+	EventType.MilestoneBought,
+	EventType.CompetitionSponsored,
+	EventType.ColonyBuilt,
+	EventType.ColonyTrading,
+	EventType.StartingSetup,
+	EventType.ProductionDone,
+	EventType.TilePlaced,
+	EventType.MarsTerraformed,
+	EventType.GlobalEventsChanged,
+	EventType.CurrentGlobalEventExecuted,
+	EventType.NewGovernment,
+	EventType.PlayerMovedDelegate,
+	EventType.CommitteePartyActivePolicyActivated,
+]
+
+export const isInYourFaceEvent = ({ event }: Params) => {
+	if (event.processed) {
+		return false
+	}
+
+	return PROCESSABLE_EVENTS.includes(event.type)
+}

--- a/client/src/utils/formatTime.ts
+++ b/client/src/utils/formatTime.ts
@@ -1,0 +1,7 @@
+export const formatTime = (time: number) => {
+	const hours = Math.floor(time / 3600000)
+	const minutes = Math.floor((time % 3600000) / 60000)
+	const seconds = ((time % 60000) / 1000).toFixed(0)
+
+	return `${hours > 0 ? hours + ':' : ''}${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`
+}


### PR DESCRIPTION
Introduce possibility to list "in-your-face" events that are normally displayed when somebody plays something. I've decided to go with "Grouped" terminology here.

When clicking on the bell icon, you'll now either open minimized pending events or history modal. The grouped events are now also accessible in the "Event log" modal thorugh a tab.

![image](https://github.com/user-attachments/assets/16db9f06-ef14-4ce2-87f1-901546b659f6)

